### PR TITLE
conf: Update configuration files for S1 and S3 use case

### DIFF
--- a/rs-cores/MONITORING/Executables/additional_resources/ConfigMap-filter.yaml
+++ b/rs-cores/MONITORING/Executables/additional_resources/ConfigMap-filter.yaml
@@ -74,7 +74,7 @@ data:
           log.trace.task.event: END
           log.trace.task.status: OK
       -
-        name: JobProcessing_Product-mutliOutput
+        name: JobProcessing_Product-multiOutput
         rules:
           log.trace.task.name: JobProcessing
           log.trace.task.event: END
@@ -90,7 +90,7 @@ data:
           log.trace.header.rs_chain_name: S3-L0P
           log.trace.task.output[filename_string]: .+
       -
-        name: JobProcessing_Product-NOK
+        name: JobProcessing_Product-onlyMissingOutput
         rules:
           log.trace.task.name: JobProcessing
           log.trace.task.event: END

--- a/rs-cores/MONITORING/Executables/additional_resources/ConfigMap-filter.yaml
+++ b/rs-cores/MONITORING/Executables/additional_resources/ConfigMap-filter.yaml
@@ -74,18 +74,26 @@ data:
           log.trace.task.event: END
           log.trace.task.status: OK
       -
-        name: JobProcessing_Product
+        name: JobProcessing_Product-mutliOutput
         rules:
           log.trace.task.name: JobProcessing
           log.trace.task.event: END
           log.trace.task.status: OK
-          log.trace.header.rs_chain_name: S1-L0AIOP|S1-L0ASP|S1-L1|S1-L2|s2-l0u|s2-l0c|S3-ACQ|S3-L0P
+          log.trace.header.rs_chain_name: S1-L0AIOP|S1-L0ASP|S1-L1|S1-L2|s2-l0u|s2-l0c|s2-l1|S3-ACQ
+          log.trace.task.output[filename_strings][0]: .+
+      -
+        name: JobProcessing_Product-singleOutput
+        rules:
+          log.trace.task.name: JobProcessing
+          log.trace.task.event: END
+          log.trace.task.status: OK
+          log.trace.header.rs_chain_name: S3-L0P
+          log.trace.task.output[filename_string]: .+
       -
         name: JobProcessing_Product-NOK
         rules:
           log.trace.task.name: JobProcessing
           log.trace.task.event: END
-          log.trace.task.status: NOK
           log.trace.task.missing_output[0]: .+
       -
         name: PripWorker_Product

--- a/rs-cores/MONITORING/Executables/additional_resources/ConfigMap-ingestor.yaml
+++ b/rs-cores/MONITORING/Executables/additional_resources/ConfigMap-ingestor.yaml
@@ -136,7 +136,7 @@ data:
             action: SUBSTRACT al1 al2
             to: product.catalog_storage_begin_date
       -
-        name: JobProcessing_Product-mutliOutput
+        name: JobProcessing_Product-multiOutput
         mappings:
           - from: log.trace.task.input[filename_strings]
             action: MATCH DCS_.+?_DSIB\.xml$
@@ -272,7 +272,7 @@ data:
         duplicate_processings:
           - query: processing.id in (select ol.processing_id from output_list ol where ol.product_id in <output_product.id>) and processing.rs_chain_name = <processing.rs_chain_name> and processing.rs_chain_version = <processing.rs_chain_version>
       -
-        name: JobProcessing_Product-NOK
+        name: JobProcessing_Product-onlyMissingOutput
         mappings:
           - from: log.trace.task.input[filename_strings]
             action: MATCH DCS_.+?_DSIB\.xml$
@@ -290,7 +290,7 @@ data:
           - from: log.trace.header.mission
             to: aux_data.mission
           - from: log.trace.task.input[filename_strings]
-            action: FORMAT ^.+(?=.zip)|.+$ %1$s
+            action: FORMAT ^S[0-9][A-Z].+(?=.zip)$|^S[0-9][A-Z].+$ %1$s
             to: input_product.filename
           - from: log.trace.task.status
             to: processing.status

--- a/rs-cores/MONITORING/Executables/additional_resources/ConfigMap-ingestor.yaml
+++ b/rs-cores/MONITORING/Executables/additional_resources/ConfigMap-ingestor.yaml
@@ -106,12 +106,12 @@ data:
           - from: log.trace.header.mission
             to: aux_data.mission
           - from: log.trace.header.timestamp
-            to: aux.catalog_storage_end_date
+            to: aux_data.catalog_storage_end_date
           - from: 
               - al1 -> log.trace.header.timestamp
               - al2 -> log.trace.task.duration_in_seconds
             action: SUBSTRACT al1 al2
-            to: aux.catalog_storage_begin_date
+            to: aux_data.catalog_storage_begin_date
           - from: log.trace.task.output[product_metadata_custom_object]
             to: aux_data.custom
       -
@@ -136,7 +136,7 @@ data:
             action: SUBSTRACT al1 al2
             to: product.catalog_storage_begin_date
       -
-        name: JobProcessing_Product
+        name: JobProcessing_Product-mutliOutput
         mappings:
           - from: log.trace.task.input[filename_strings]
             action: MATCH DCS_.+?_DSIB\.xml$
@@ -166,7 +166,7 @@ data:
             action: SUBSTRACT al1 al2
             to: output_product.generation_begin_date
           - from: log.trace.task.input[filename_strings]
-            action: FORMAT ^.+(?=.zip)|.+$ %1$s
+            action: FORMAT ^S[0-9][A-Z].+(?=.zip)$|^S[0-9][A-Z].+$ %1$s
             to: input_product.filename
           - from: log.trace.task.status
             to: processing.status
@@ -204,7 +204,73 @@ data:
               log.trace.header.rs_chain_name: S1-L0AIOP|s2-l0u|S3-ACQ
           - query: processing.id in (select ili.processing_id from input_list_internal ili where ili.product_id in <input_product.id>) and processing.rs_chain_name = <processing.rs_chain_name> and processing.rs_chain_version = <processing.rs_chain_version>
             rules:
-              log.trace.header.rs_chain_name: S1-L0ASP|S1-L1|S1-L2|s2-l0c|S3-L0P
+              log.trace.header.rs_chain_name: S1-L0ASP|S1-L1|S1-L2|s2-l0c|s2-l1
+          - query: processing.id in (select ol.processing_id from output_list ol where ol.product_id in <output_product.id>) and processing.rs_chain_name = <processing.rs_chain_name> and processing.rs_chain_version = <processing.rs_chain_version>
+      -
+        name: JobProcessing_Product-singleOutput
+        mappings:
+          - from: log.trace.task.input[filename_strings]
+            action: MATCH DCS_.+?_DSIB\.xml$
+            to: dsib.filename
+          - from: log.trace.header.mission
+            to: dsib.mission
+          - from: log.trace.task.input[filename_strings]
+            action: MATCH DCS_.+?\.raw$
+            to: chunk.filename
+          - from: log.trace.header.mission
+            to: chunk.mission
+          - from: log.trace.task.input[filename_strings]
+            action: MATCH ^(S1.*(AUX_|AMH_|AMV_|MPL_ORB).*)|(S1.*(_OPER_REP_MP_MP__PDMC_|_OPER_REP__SUP___|_OPER_MPL_SP.{4}_PDMC_|_OPER_REP_STNACQ_.{4}_|_OPER_REP_STNUNV_.{4}_|_OPER_AM[VH_]_FAILUR_MPC__|_OPER_REP__MACP__).*\.(zip|ZIP))|((S2)(A|B|_)_(OPER|TEST)_((AUX|GIP)_[0-9A-Z_]{7})(.*)\.TGZ)|(S3[AB_]_([0-9a-zA-Z_]{9})AX_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_([0-9]{8}T[0-9]{6})_(_{17})_([0-9a-zA-Z_]{3})_(((O|F|R|D|_)_(NR|NT|ST|SN|NS|NN|AL|__)_([a-zA-Z0-9_]{3}))|_{8})\.SEN3\.(zip|ZIP))$
+            to: aux_data.filename
+          - from: log.trace.header.mission
+            to: aux_data.mission
+          - from: log.trace.task.output[filename_string]
+            action: FORMAT ^.+(?=.zip)|.+$ %1$s
+            to: output_product.filename
+          - from: log.trace.task.output[t0_pdgs_date]
+            to: output_product.t0_pdgs_date
+          - from: log.trace.header.timestamp
+            to: output_product.generation_end_date
+          - from: 
+              - al1 -> log.trace.header.timestamp
+              - al2 -> log.trace.task.duration_in_seconds
+            action: SUBSTRACT al1 al2
+            to: output_product.generation_begin_date
+          - from: log.trace.task.input[filename_strings]
+            action: FORMAT ^S[0-9][A-Z].+(?=.zip)$|^S[0-9][A-Z].+$ %1$s
+            to: input_product.filename
+          - from: log.trace.task.status
+            to: processing.status
+          - from: log.trace.header.mission
+            to: processing.mission
+          - from: log.trace.header.level
+            to: processing.level
+          - from: log.trace.header.workflow
+            to: processing.workflow
+          - from: log.trace.task.output[t0_pdgs_date]
+            to: processing.t0_pdgs_date
+          - from: log.trace.header.rs_chain_name
+            to: processing.rs_chain_name
+          - from: log.trace.header.rs_chain_version
+            to: processing.rs_chain_version
+          - from: log.trace.header.timestamp
+            to: processing.processing_date
+          - from: log.trace.task.missing_output[product_metadata_custom_object]
+            remove_entity_if_null: true
+            to: missing_products.product_metadata_custom
+          - from: log.trace.task.missing_output[end_to_end_product_boolean]
+            to: missing_products.end_to_end_product
+          - from: log.trace.task.missing_output[estimated_count_integer]
+            to: missing_products.estimated_count
+        alias:
+          input_product:
+            entity: product
+            restrict: input_list_internal
+          output_product:
+            entity: product
+            restrict: output_list
+        duplicate_processings:
+          - query: processing.id in (select ol.processing_id from output_list ol where ol.product_id in <output_product.id>) and processing.rs_chain_name = <processing.rs_chain_name> and processing.rs_chain_version = <processing.rs_chain_version>
       -
         name: JobProcessing_Product-NOK
         mappings:

--- a/rs-cores/MONITORING/Executables/additional_resources/ConfigMap-ingestor.yaml
+++ b/rs-cores/MONITORING/Executables/additional_resources/ConfigMap-ingestor.yaml
@@ -202,10 +202,10 @@ data:
           - query: processing.id in (select ile.processing_id from input_list_external ile where ile.external_input_id in <chunk.id,dsib.id>) and processing.rs_chain_name = <processing.rs_chain_name> and processing.rs_chain_version = <processing.rs_chain_version>
             rules:
               log.trace.header.rs_chain_name: S1-L0AIOP|s2-l0u|S3-ACQ
-          - query: processing.id in (select ili.processing_id from input_list_internal ili where ili.product_id in <input_product.id>) and processing.rs_chain_name = <processing.rs_chain_name> and processing.rs_chain_version = <processing.rs_chain_version>
+          - query: processing.id in (select ol.processing_id from output_list ol where ol.product_id in <output_product.id>) and processing.rs_chain_name = <processing.rs_chain_name> and processing.rs_chain_version = <processing.rs_chain_version>
             rules:
               log.trace.header.rs_chain_name: S1-L0ASP|S1-L1|S1-L2|s2-l0c|s2-l1
-          - query: processing.id in (select ol.processing_id from output_list ol where ol.product_id in <output_product.id>) and processing.rs_chain_name = <processing.rs_chain_name> and processing.rs_chain_version = <processing.rs_chain_version>
+          - query: processing.id in (select ili.processing_id from input_list_internal ili where ili.product_id in <input_product.id>) and processing.rs_chain_name = <processing.rs_chain_name> and processing.rs_chain_version = <processing.rs_chain_version>
       -
         name: JobProcessing_Product-singleOutput
         mappings:


### PR DESCRIPTION
- Correction du mapping pour les aux_data (aux_data au lieu de aux)
- Ajout d'une configuration de mapping lorsqu'il n'y au qu'un seul produit de créer (filename_string au lieu de filename_strings) => cas du S3-L0P
- Renforcement des règles sur les traces JobProcessing pour vérifier que le champ filename_string est bien renseigné
- Suppression du contrôle sur le status NOK d'une trace JobProcessing pour prendre le cas du S3-L0P où l'on peut avoir un traitement qui se termine nominalement sans produit créé mais avec un missing_output renseigné
- Utilisation des output product plutôt que des input pour éviter des taguer des processing duplicate alors qu'il ne sont pas identiques (production d'output différent pour un même input)